### PR TITLE
各問題の正解を表示するボタンの実装と、ゲームの最後に正解一覧を表示できるよう修正

### DIFF
--- a/app/src/main/java/com/example/unscramble/ui/GameScreen.kt
+++ b/app/src/main/java/com/example/unscramble/ui/GameScreen.kt
@@ -98,6 +98,7 @@ fun GameScreen(gameViewModel: GameViewModel) {
             isGuessWrong = gameUiState.isGuessedWordWrong,
             onUserGuessChanged = { gameViewModel.updateUserGuess(it) },
             onKeyboardDone = { gameViewModel.checkUserGuess() },
+            updateIsShowAnswer = gameViewModel::updateIsShowAnswer,
             modifier = Modifier
                 .fillMaxWidth()
                 .wrapContentHeight()
@@ -143,6 +144,13 @@ fun GameScreen(gameViewModel: GameViewModel) {
                     onPlayAgain = { gameViewModel.resetGame() }
                 )
             }
+
+            if (gameUiState.isShowAnswer) {
+                CorrectWordDialog(
+                    word = gameUiState.currentWord.answer,
+                    updateIsShowAnswer = gameViewModel::updateIsShowAnswer
+                )
+            }
         }
     }
 }
@@ -175,6 +183,7 @@ fun GameLayout(
     isGuessWrong: Boolean,
     onUserGuessChanged: (String) -> Unit,
     onKeyboardDone: () -> Unit,
+    updateIsShowAnswer: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
     currentWord: Word,
     userGuess: String
@@ -185,6 +194,14 @@ fun GameLayout(
         modifier = modifier,
         elevation = CardDefaults.cardElevation(defaultElevation = 5.dp)
     ) {
+        TextButton(
+            onClick = { updateIsShowAnswer(true) },
+            modifier = Modifier
+                .align(Alignment.End),
+        ) {
+            Text(text = stringResource(id = R.string.answer))
+        }
+
         Column(
             verticalArrangement = Arrangement.spacedBy(mediumPadding),
             horizontalAlignment = Alignment.CenterHorizontally,

--- a/app/src/main/java/com/example/unscramble/ui/GameScreen.kt
+++ b/app/src/main/java/com/example/unscramble/ui/GameScreen.kt
@@ -141,6 +141,7 @@ fun GameScreen(gameViewModel: GameViewModel) {
             if (gameUiState.isGameOver) {
                 FinalScoreDialog(
                     score = gameUiState.score,
+                    correctList = gameViewModel.createCorrectList(),
                     onPlayAgain = { gameViewModel.resetGame() }
                 )
             }
@@ -257,6 +258,7 @@ fun GameLayout(
 @Composable
 private fun FinalScoreDialog(
     score: Int,
+    correctList: String,
     onPlayAgain: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -265,7 +267,7 @@ private fun FinalScoreDialog(
     AlertDialog(
         onDismissRequest = {},
         title = { Text(text = stringResource(R.string.congratulations)) },
-        text = { Text(text = stringResource(R.string.you_scored, score)) },
+        text = { Text(text = stringResource(id = R.string.correct_list, score, correctList)) },
         modifier = modifier,
         dismissButton = {
             TextButton(
@@ -282,6 +284,39 @@ private fun FinalScoreDialog(
             }
         }
     )
+}
+
+@Composable
+private fun CorrectWordDialog(
+    word: String,
+    updateIsShowAnswer: (Boolean) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val openDialog = remember { mutableStateOf(true) }
+
+    if (openDialog.value) {
+        AlertDialog(
+            onDismissRequest = {},
+            text = {
+                Text(
+                    text = word,
+                    fontSize = 45.sp
+                )
+            },
+            modifier = modifier,
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        openDialog.value = false
+                        updateIsShowAnswer(false)
+                    }
+                ) {
+                    Text(text = stringResource(R.string.close))
+                }
+            },
+            dismissButton = null
+        )
+    }
 }
 
 @Preview(showBackground = true)

--- a/app/src/main/java/com/example/unscramble/ui/GameViewModel.kt
+++ b/app/src/main/java/com/example/unscramble/ui/GameViewModel.kt
@@ -98,4 +98,15 @@ class GameViewModel : ViewModel() {
         // 単語入力欄を空にする
         updateUserGuess("")
     }
+
+    /**
+     * isShowAnswerのフラグを更新
+     */
+    fun updateIsShowAnswer(isShow: Boolean) {
+        _uiState.update { currentState ->
+            currentState.copy(
+                isShowAnswer = isShow
+            )
+        }
+    }
 }

--- a/app/src/main/java/com/example/unscramble/ui/GameViewModel.kt
+++ b/app/src/main/java/com/example/unscramble/ui/GameViewModel.kt
@@ -1,5 +1,6 @@
 package com.example.unscramble.ui
 
+import android.util.Log
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -97,6 +98,22 @@ class GameViewModel : ViewModel() {
         updateGameState(_uiState.value.score)
         // 単語入力欄を空にする
         updateUserGuess("")
+    }
+
+    /**
+     * 正解の単語リストを生成
+     */
+    fun createCorrectList(): String {
+        val correctList: MutableList<String> = emptyList<String>().toMutableList()
+        allWords.forEach {
+            // 問題に出した単語のみのリストを生成
+            if (it.isUsed) correctList.add(it.answer)
+        }
+
+        val separator = ", "
+        // 「,」で繋がったStringを生成
+        val str = correctList.joinToString(separator)
+        return str.replace(",", "\n")
     }
 
     /**

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,4 +27,8 @@
     <string name="exit">Exit</string>
     <string name="play_again">Play Again</string>
     <string name="wrong_guess">Wrong Guess!</string>
+    <string name="correct_list">"You scored: %d"\n\n----------------------\n正解一覧\n ----------------------\n %s</string>
+    <string name="close">Close</string>
+    <string name="correct">Correct</string>
+    <string name="answer">answer</string>
 </resources>


### PR DESCRIPTION

## 対応内容

* 各問題の正解を確認できるAnserボタンを追加
* ゲームの最後に正解一覧を表示できるようダイアログ内の表示を修正


## レビュー観点

* 実装に違和感はないか

## 期待動作

* 各問題の答えがダイアログ表示できるか
* ゲームの最後に正解一覧が確認できるか

## スクリーンショット

| before | after |
|--------|-------|
|<img src="https://github.com/yanPWA/Unscramble/assets/82929509/9b42f0b9-c2ff-46e3-a4a5-14466a8b8e0f" width="200px"/>|<img src="https://github.com/yanPWA/Unscramble/assets/82929509/c840f279-7758-497f-b779-e771e781f7ed" width="200px"/>|


| before | after |
|--------|-------|
|<img src="https://github.com/yanPWA/Unscramble/assets/82929509/e883850f-f553-48a2-9629-ca7e0a4ff63e" width="200px"/>|<img src="https://github.com/yanPWA/Unscramble/assets/82929509/6d6fd98f-93a9-4230-afdf-b76628b844d9" width="200px"/>|

